### PR TITLE
Assert on data being sent to stdout and stderr

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@
   other than just the one specified in config
 - Support for running a test by name
   - Accessed with args.name in main.rs
-- Test tagging?
 - Script documentation
 - Add JSON support
   - Ex, `var foo = LITERAL JSON {"test":5};`

--- a/src/abstract_syntax_tree.rs
+++ b/src/abstract_syntax_tree.rs
@@ -899,7 +899,7 @@ impl std::fmt::Display for Value {
 impl Value {
     pub fn error_print(&self) -> String {
         match self {
-            Value::Literal(literal) => format!("value {}", literal),
+            Value::Literal(literal) => format!("value '{}'", literal),
             Value::Variable(var_name) => format!("var '{}'", var_name.to_owned()),
             Value::FormattedString(formatted_string) => format!("fmt_str '{:?}'", formatted_string),
         }

--- a/src/commands/print.rs
+++ b/src/commands/print.rs
@@ -3,10 +3,12 @@ use crate::err_handle::ChimeraRuntimeFailure;
 use crate::frontend::{print_in_function, Context};
 use crate::literal::DataKind;
 use crate::variable_map::VariableMap;
+use std::io::Write;
 use std::ops::Deref;
 
-pub fn print_command(
+pub fn print_command<W: Write>(
     context: &Context,
+    writer: &mut W,
     print_cmd: Value,
     variable_map: &VariableMap,
     depth: usize,
@@ -14,8 +16,8 @@ pub fn print_command(
     let resolved = print_cmd.resolve(context, variable_map)?;
     let borrowed = resolved.borrow(context)?;
     match borrowed.deref() {
-        DataKind::Literal(literal) => print_in_function(literal, depth),
-        DataKind::Collection(collection) => print_in_function(collection, depth),
+        DataKind::Literal(literal) => print_in_function(writer, literal, depth),
+        DataKind::Collection(collection) => print_in_function(writer, collection, depth),
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use crate::abstract_syntax_tree::ChimeraScriptAST;
 use crate::err_handle::CLIError;
 use clap::Parser;
 use std::fs;
+use std::io::{stderr, stdout, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::OnceLock;
@@ -51,7 +52,11 @@ fn system_checks() {
     }
 }
 
-fn walk_directory(path: &Path) -> Result<ResultCount, CLIError> {
+fn walk_directory<S: Write, E: Write>(
+    writer: &mut S,
+    error_writer: &mut E,
+    path: &Path,
+) -> Result<ResultCount, CLIError> {
     let mut result_count = ResultCount::new((0, 0, 0, 0));
     if !path.is_dir() {
         return Err(CLIError::new(
@@ -77,17 +82,21 @@ fn walk_directory(path: &Path) -> Result<ResultCount, CLIError> {
                 continue;
             }
             // Run a test file and get its results
-            let count = run_test_file(entry_path.as_path())?;
+            let count = run_test_file(writer, error_writer, entry_path.as_path())?;
             result_count = result_count + count;
         } else if entry_path.is_dir() {
-            let count = walk_directory(entry_path.as_path())?;
+            let count = walk_directory(writer, error_writer, entry_path.as_path())?;
             result_count = result_count + count;
         }
     }
     Ok(result_count)
 }
 
-fn run_test_file(path: &Path) -> Result<ResultCount, CLIError> {
+fn run_test_file<S: Write, E: Write>(
+    writer: &mut S,
+    error_writer: &mut E,
+    path: &Path,
+) -> Result<ResultCount, CLIError> {
     // The file should have a .chs extension if we want to run it
     let extension = path.extension();
     if extension.is_none() || extension.unwrap() != FILE_EXTENSION {
@@ -118,6 +127,8 @@ fn run_test_file(path: &Path) -> Result<ResultCount, CLIError> {
             let results = if test_name.is_some() {
                 let test_name = test_name.clone().unwrap();
                 frontend::run_function_by_name(
+                    writer,
+                    error_writer,
                     ast,
                     path.file_name()
                         .expect("Failed to get file name when running functions"),
@@ -125,6 +136,8 @@ fn run_test_file(path: &Path) -> Result<ResultCount, CLIError> {
                 )
             } else {
                 frontend::run_functions(
+                    writer,
+                    error_writer,
                     ast,
                     path.file_name()
                         .expect("Failed to get file name when running functions"),
@@ -133,7 +146,7 @@ fn run_test_file(path: &Path) -> Result<ResultCount, CLIError> {
             Ok(ResultCount::from_test_results(results))
         }
         Err(e) => {
-            e.print_error();
+            e.print_error(error_writer);
             // This is a hack, see the comment in main() and the to-do in err_handle.rs
             Err(CLIError::new("".to_string(), true))
         }
@@ -148,7 +161,7 @@ fn main() {
     let config = match Config::from_path_str(&args.config) {
         Ok(config) => config,
         Err(err_msg) => {
-            print_error(&err_msg);
+            print_error(&mut stderr(), &err_msg);
             return;
         }
     };
@@ -179,17 +192,22 @@ fn main() {
         .expect("infallible method failed when creating PathBuf from str");
     let path_slice = path.as_path();
     if !path.exists() {
-        print_error(&format!("{} is not a valid path", path_slice.display()));
+        print_error(
+            &mut stderr(),
+            &format!("{} is not a valid path", path_slice.display()),
+        );
         return;
     }
 
     let timer = Timer::new();
 
+    // TODO: I should probably be using some struct here that handles print/eprint rather
+    //       than using std handles
     // Check if we were given a directory or a file
     let results = if path_slice.is_dir() {
-        walk_directory(path_slice)
+        walk_directory(&mut stdout(), &mut stderr(), path_slice)
     } else if path_slice.is_file() {
-        run_test_file(path_slice)
+        run_test_file(&mut stdout(), &mut stderr(), path_slice)
     } else {
         Err(CLIError::new(
             "The given path was not a directory or file, when it must be one of those two"
@@ -201,14 +219,14 @@ fn main() {
     match results {
         Ok(res) => {
             let run_time = timer.finish();
-            res.print_with_time(run_time.as_str());
+            res.print_with_time(&mut stdout(), run_time.as_str());
         }
         Err(e) => {
             // This is a hack to reconcile reporting both the CLI errors in this file and the
             // compilation errors from ChimeraScriptAST::new
             // If we reported a compile time error, then we don't want to report a CLI error
             if !e.already_reported {
-                e.print_error()
+                e.print_error(&mut stderr())
             }
         }
     }
@@ -216,6 +234,7 @@ fn main() {
 
 #[cfg(test)]
 mod main_tests {
+    use crate::testing::util::test_writer::TestWriter;
     use crate::{run_test_file, walk_directory, TEST_NAME};
     use std::path::Path;
 
@@ -228,10 +247,12 @@ mod main_tests {
     #[test]
     fn test_run_test_file() {
         initialize();
+        let mut std_out = TestWriter::new();
+        let mut std_err = TestWriter::new();
 
         // Verify we get an error when running a test file with a file that doesn't exist
         let bad_path = Path::new("./src/testing/chs_files/idontexist.chs");
-        let res = run_test_file(bad_path);
+        let res = run_test_file(&mut std_out, &mut std_err, bad_path);
         assert!(
             res.is_err(),
             "Trying to run a file that does not exist should error"
@@ -239,7 +260,7 @@ mod main_tests {
 
         // Verify we get an error when running a non chs file
         let wrong_type_path = Path::new("./src/testing/chs_files/directory_tests/skipme.json");
-        let res = run_test_file(wrong_type_path);
+        let res = run_test_file(&mut std_out, &mut std_err, wrong_type_path);
         assert!(
             res.is_err(),
             "Trying to run a file that does not have a .chs extension should error"
@@ -247,7 +268,7 @@ mod main_tests {
 
         // Verify we get an error when running a test file with a directory
         let wrong_type_path = Path::new("./src/testing/chs_files/directory_tests/");
-        let res = run_test_file(wrong_type_path);
+        let res = run_test_file(&mut std_out, &mut std_err, wrong_type_path);
         assert!(
             res.is_err(),
             "Trying to run a test file but passing a directory should error"
@@ -255,22 +276,24 @@ mod main_tests {
 
         // Run a simple test
         let literal_test_path = Path::new("./src/testing/chs_files/simplest_test.chs");
-        let res = run_test_file(literal_test_path);
+        let res = run_test_file(&mut std_out, &mut std_err, literal_test_path);
         assert!(res.is_ok(), "Running a simple chs test should Ok");
     }
 
     #[test]
     fn test_walk_directory() {
         initialize();
+        let mut std_out = TestWriter::new();
+        let mut std_err = TestWriter::new();
 
         // Try to walk directory on a file, which should fail
         let literal_test_path = Path::new("./src/testing/chs_files/simplest_test.chs");
-        let res = walk_directory(literal_test_path);
+        let res = walk_directory(&mut std_out, &mut std_err, literal_test_path);
         assert!(res.is_err(), "Passing walk_directory a file should Err");
 
         // Walk a directory, should only run .chs files
         let path = Path::new("./src/testing/chs_files/directory_tests/");
-        let res = walk_directory(path);
+        let res = walk_directory(&mut std_out, &mut std_err, path);
         assert!(res.is_ok(), "Passing walk_directory a directory should Ok");
         let result_count = res.unwrap();
         assert_eq!(result_count.success_count(), 3);

--- a/src/testing/chs_files/print.chs
+++ b/src/testing/chs_files/print.chs
@@ -1,6 +1,19 @@
 [test]
-case print-case() {
+case print_case() {
+  // Print a normal string
   PRINT "Hello world";
+
+  // Print a variable
   var num = LITERAL 5;
   PRINT (num);
+
+  // Test formatted strings
+  var one = LITERAL "test";
+  var two = LITERAL "test";
+
+  // Test a formatted string using a single variable
+  PRINT "test (one) test";
+
+  // Test a formatted string using multiple variables
+  PRINT "test (one) (two) test";
 }

--- a/src/testing/util/fake_client.rs
+++ b/src/testing/util/fake_client.rs
@@ -1,0 +1,83 @@
+use crate::abstract_syntax_tree::{HTTPVerb, HttpCommand};
+use crate::err_handle::ChimeraRuntimeFailure;
+use crate::frontend::Context;
+use crate::literal::{Collection, Data, DataKind, Literal, NumberKind};
+use crate::util::client::WebClient;
+use crate::variable_map::VariableMap;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct FakeClient {
+    domain: String,
+}
+
+impl FakeClient {
+    #[allow(dead_code)] // Used in test
+    pub fn new(s: &str) -> Self {
+        let domain = s.to_owned();
+        Self { domain }
+    }
+}
+
+impl WebClient for FakeClient {
+    fn get_domain(&self) -> &str {
+        self.domain.as_str()
+    }
+    fn make_request(
+        &self,
+        context: &Context,
+        http_command: HttpCommand,
+        variable_map: &VariableMap,
+    ) -> Result<DataKind, ChimeraRuntimeFailure> {
+        let mut response_obj: HashMap<String, Data> = HashMap::new();
+        response_obj.insert(
+            "status_code".to_owned(),
+            Data::from_literal(Literal::Number(NumberKind::U64(match http_command.verb {
+                HTTPVerb::Get => 200,
+                HTTPVerb::Delete => 200,
+                HTTPVerb::Post => 201,
+                HTTPVerb::Put => 200,
+            }))),
+        );
+
+        // Take a request and extract the query and body params from it
+        let mut resolved_body: HashMap<String, Data> = HashMap::new();
+        for assignment in &http_command.http_assignments {
+            let key = assignment.lhs.clone();
+            let value = assignment.rhs.resolve(context, variable_map)?;
+            resolved_body.insert(key, value);
+        }
+        let mut query_params: HashMap<String, Data> = HashMap::new();
+        for query_param in &http_command.query_params {
+            let key = query_param.lhs.clone();
+            let value = query_param.rhs.resolve(context, variable_map)?;
+            query_params.insert(key, value);
+        }
+        let raw_headers = &http_command.resolve_header(context, variable_map)?;
+        let mut headers: HashMap<String, Data> = HashMap::new();
+        for (key, value) in raw_headers.iter() {
+            let deserializable_value = format!("\"{}\"", value.to_str().unwrap());
+            let data = Data::new(serde_json::from_slice(deserializable_value.as_bytes()).unwrap());
+            headers.insert(key.to_string(), data);
+        }
+
+        // Construct a response struct out of the request params
+        let mut body_data: HashMap<String, Data> = HashMap::new();
+        let resolved_path = http_command.resolve_path(context, variable_map)?;
+        body_data.insert(
+            "path".to_owned(),
+            Data::new(DataKind::Literal(Literal::String(resolved_path))),
+        );
+        if !resolved_body.is_empty() || !query_params.is_empty() || !headers.is_empty() {
+            body_data.extend(query_params);
+            body_data.extend(resolved_body);
+            body_data.extend(headers);
+        }
+
+        response_obj.insert(
+            "body".to_owned(),
+            Data::new(DataKind::Collection(Collection::Object(body_data))),
+        );
+        Ok(DataKind::Collection(Collection::Object(response_obj)))
+    }
+}

--- a/src/testing/util/mod.rs
+++ b/src/testing/util/mod.rs
@@ -1,0 +1,2 @@
+pub mod fake_client;
+pub mod test_writer;

--- a/src/testing/util/test_writer.rs
+++ b/src/testing/util/test_writer.rs
@@ -1,0 +1,39 @@
+use std::io;
+use std::io::Write;
+
+pub struct TestWriter {
+    pub buffer: String,
+}
+
+impl TestWriter {
+    #[allow(dead_code)] // Used in test
+    pub fn new() -> Self {
+        Self {
+            buffer: String::new(),
+        }
+    }
+    #[allow(dead_code)] // Used in test
+    pub fn str_lines(&self) -> Vec<&str> {
+        self.buffer.lines().collect::<Vec<&str>>()
+    }
+}
+
+impl Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match std::str::from_utf8(buf) {
+            Ok(s) => {
+                self.buffer.push_str(s);
+                Ok(buf.len())
+            }
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid UTF-8 sequence",
+            )),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // Empty buffer and then Ok?
+        Ok(())
+    }
+}


### PR DESCRIPTION
Functions which either print or call something which will print now take two `impl Write` args. Handles to `stdout` and `stderr` are used outside of tests, but a dummy struct made to represent them is passed during testing. This allows tests to assert against data being printed.