### PR TITLE
Refactor variable map usage

### DIFF
--- a/src/abstract_syntax_tree.rs
+++ b/src/abstract_syntax_tree.rs
@@ -901,7 +901,8 @@ impl Value {
             Value::Literal(literal) => format!("value '{}'", literal),
             Value::Variable(var_name) => format!("var '{}'", var_name.to_owned()),
             Value::FormattedString(_) => {
-                // Don't want to return a string here as it will result in an error message like
+                // If the resolve here fails, we don't want to swap out the error string for an
+                // "internal error" message as it will result in an error message like
                 // "Expected 'foo' to equal 'Internal error'". This is a bad state that should
                 // not occur, so we will panic
                 let resolved = self

--- a/src/abstract_syntax_tree.rs
+++ b/src/abstract_syntax_tree.rs
@@ -1,7 +1,6 @@
 use crate::err_handle::{ChimeraCompileError, ChimeraRuntimeFailure, VarTypes};
 use crate::frontend::{Context, Rule};
 use crate::literal::{Data, DataKind, Literal, NumberKind};
-use crate::variable_map::VariableMap;
 use crate::{frontend, CLIENT};
 use pest::iterators::Pair;
 use reqwest::header::{HeaderMap, HeaderName};
@@ -897,32 +896,37 @@ impl std::fmt::Display for Value {
 }
 
 impl Value {
-    pub fn error_print(&self) -> String {
+    pub fn error_print(&self, context: &Context) -> String {
         match self {
             Value::Literal(literal) => format!("value '{}'", literal),
             Value::Variable(var_name) => format!("var '{}'", var_name.to_owned()),
-            Value::FormattedString(formatted_string) => format!("fmt_str '{:?}'", formatted_string),
+            Value::FormattedString(_) => {
+                // Don't want to return a string here as it will result in an error message like
+                // "Expected 'foo' to equal 'Internal error'". This is a bad state that should
+                // not occur, so we will panic
+                let resolved = self
+                    .resolve(context)
+                    .expect("Internal error while resolving a formatted string");
+                let binding = resolved
+                    .borrow()
+                    .expect("Internal error while resolving a formatted string");
+                format!("formatted string '{}'", binding)
+            }
         }
     }
 
-    pub fn resolve(
-        &self,
-        context: &Context,
-        variable_map: &VariableMap,
-    ) -> Result<Data, ChimeraRuntimeFailure> {
+    pub fn resolve(&self, context: &Context) -> Result<Data, ChimeraRuntimeFailure> {
         match self {
             Value::Literal(val) => Ok(Data::from_literal(val.clone())),
-            Value::Variable(var_name) => {
-                Ok(Self::get_from_var_map(context, var_name, variable_map)?)
-            }
+            Value::Variable(var_name) => Ok(Self::get_from_var_map(context, var_name)?),
             Value::FormattedString(formatted_string) => {
                 let mut built_str: String = String::new();
                 for value in formatted_string {
                     match value {
                         Self::Literal(literal) => built_str.push_str(literal.to_string().as_str()),
                         Self::Variable(var_name) => {
-                            let resolved = Self::get_from_var_map(context, var_name, variable_map)?;
-                            let binding = resolved.borrow(context)?;
+                            let resolved = Self::get_from_var_map(context, var_name)?;
+                            let binding = resolved.borrow()?;
                             let as_string = binding.to_string();
                             built_str.push_str(as_string.as_str());
                         },
@@ -934,12 +938,9 @@ impl Value {
         }
     }
 
-    fn get_from_var_map(
-        context: &Context,
-        var_name: &str,
-        variable_map: &VariableMap,
-    ) -> Result<Data, ChimeraRuntimeFailure> {
+    fn get_from_var_map(context: &Context, var_name: &str) -> Result<Data, ChimeraRuntimeFailure> {
         let accessors: Vec<&str> = var_name.split('.').collect();
+        let variable_map = context.get_var_map();
         let value = variable_map.get(context, accessors[0])?;
         if accessors.len() == 1 {
             Ok(value.clone())
@@ -1002,25 +1003,17 @@ impl From<Statement> for HttpCommand {
 }
 
 impl HttpCommand {
-    pub fn resolve_path(
-        &self,
-        context: &Context,
-        variable_map: &VariableMap,
-    ) -> Result<String, ChimeraRuntimeFailure> {
+    pub fn resolve_path(&self, context: &Context) -> Result<String, ChimeraRuntimeFailure> {
         let client = CLIENT
             .get()
             .expect("Failed to get web client while resolving an HTTP expression");
         let mut resolved_path: String = client.get_domain().to_owned();
         for portion in &self.path {
-            match portion
-                .resolve(context, variable_map)?
-                .borrow(context)?
-                .deref()
-            {
+            match portion.resolve(context)?.borrow()?.deref() {
                 DataKind::Literal(literal) => resolved_path.push_str(literal.to_string().as_str()),
                 DataKind::Collection(_) => {
                     return Err(ChimeraRuntimeFailure::VarWrongType(
-                        portion.error_print(),
+                        portion.error_print(context),
                         VarTypes::Literal,
                         context.current_line,
                     ))
@@ -1035,8 +1028,8 @@ impl HttpCommand {
             } else {
                 resolved_path.push('&');
             }
-            let data = query_param.rhs.resolve(context, variable_map)?;
-            let borrowed_data = data.borrow(context)?;
+            let data = query_param.rhs.resolve(context)?;
+            let borrowed_data = data.borrow()?;
             // TODO: This currently allows for a collection var to be used here, is that actually what I want? Should this error?
             let formatted = format!("{}={}", query_param.lhs, borrowed_data);
             resolved_path.push_str(formatted.as_str());
@@ -1046,25 +1039,16 @@ impl HttpCommand {
     pub fn resolve_body(
         &self,
         context: &Context,
-        variable_map: &VariableMap,
     ) -> Result<HashMap<String, String>, ChimeraRuntimeFailure> {
         let mut body_map: HashMap<String, String> = HashMap::new();
         for assignment in &self.http_assignments {
             let key = assignment.lhs.clone();
-            let value = assignment
-                .rhs
-                .resolve(context, variable_map)?
-                .borrow(context)?
-                .to_string();
+            let value = assignment.rhs.resolve(context)?.borrow()?.to_string();
             body_map.insert(key, value);
         }
         Ok(body_map)
     }
-    pub fn resolve_header(
-        &self,
-        context: &Context,
-        variable_map: &VariableMap,
-    ) -> Result<HeaderMap, ChimeraRuntimeFailure> {
+    pub fn resolve_header(&self, context: &Context) -> Result<HeaderMap, ChimeraRuntimeFailure> {
         let mut headers: HeaderMap = HeaderMap::new();
         for pair in &self.headers {
             let header_name = match HeaderName::from_lowercase(pair.lhs.as_bytes()) {
@@ -1076,13 +1060,7 @@ impl HttpCommand {
                     ))
                 }
             };
-            let value = match pair
-                .rhs
-                .resolve(context, variable_map)?
-                .borrow(context)?
-                .to_string()
-                .parse()
-            {
+            let value = match pair.rhs.resolve(context)?.borrow()?.to_string().parse() {
                 Ok(val) => val,
                 Err(_) => {
                     return Err(ChimeraRuntimeFailure::InternalError(

--- a/src/commands/assignment.rs
+++ b/src/commands/assignment.rs
@@ -1,18 +1,13 @@
 use crate::abstract_syntax_tree::AssignmentExpr;
 use crate::err_handle::ChimeraRuntimeFailure;
 use crate::frontend::Context;
-use crate::variable_map::VariableMap;
 
 pub fn assignment_command(
-    context: &Context,
+    context: &mut Context,
     assignment_command: AssignmentExpr,
-    variable_map: &mut VariableMap,
 ) -> Result<(), ChimeraRuntimeFailure> {
-    let val_to_store = crate::commands::expression::expression_command(
-        context,
-        assignment_command.expression,
-        variable_map,
-    )?;
-    variable_map.insert(assignment_command.var_name, val_to_store);
+    let val_to_store =
+        crate::commands::expression::expression_command(context, assignment_command.expression)?;
+    context.store_data(assignment_command.var_name, val_to_store);
     Ok(())
 }

--- a/src/commands/print.rs
+++ b/src/commands/print.rs
@@ -2,7 +2,6 @@ use crate::abstract_syntax_tree::Value;
 use crate::err_handle::ChimeraRuntimeFailure;
 use crate::frontend::{print_in_function, Context};
 use crate::literal::DataKind;
-use crate::variable_map::VariableMap;
 use std::io::Write;
 use std::ops::Deref;
 
@@ -10,11 +9,10 @@ pub fn print_command<W: Write>(
     context: &Context,
     writer: &mut W,
     print_cmd: Value,
-    variable_map: &VariableMap,
     depth: usize,
 ) -> Result<(), ChimeraRuntimeFailure> {
-    let resolved = print_cmd.resolve(context, variable_map)?;
-    let borrowed = resolved.borrow(context)?;
+    let resolved = print_cmd.resolve(context)?;
+    let borrowed = resolved.borrow()?;
     match borrowed.deref() {
         DataKind::Literal(literal) => print_in_function(writer, literal, depth),
         DataKind::Collection(collection) => print_in_function(writer, collection, depth),

--- a/src/err_handle.rs
+++ b/src/err_handle.rs
@@ -82,7 +82,7 @@ pub enum ChimeraRuntimeFailure {
     BadSubfieldAccess(Option<String>, String, i32),
     TriedToIndexWithNonNumber(i32),
     OutOfBounds(i32),
-    BorrowError(i32, String),
+    BorrowError(String),
     InvalidHeader(i32, String),
 }
 
@@ -139,8 +139,8 @@ impl Display for ChimeraRuntimeFailure {
                 "ERROR on line {}: Tried to access an array with an out-of-bounds value",
                 line
             ),
-            ChimeraRuntimeFailure::BorrowError(line, reason) => {
-                write!(f, "ERROR on line {}: {}", line, reason)
+            ChimeraRuntimeFailure::BorrowError(reason) => {
+                write!(f, "ERROR: {}", reason)
             }
             ChimeraRuntimeFailure::InvalidHeader(line, header) => write!(
                 f,
@@ -178,8 +178,8 @@ impl PartialEq for ChimeraRuntimeFailure {
             ChimeraRuntimeFailure::OutOfBounds(_) => {
                 matches!(other, ChimeraRuntimeFailure::OutOfBounds(_))
             }
-            ChimeraRuntimeFailure::BorrowError(_, _) => {
-                matches!(other, ChimeraRuntimeFailure::BorrowError(_, _))
+            ChimeraRuntimeFailure::BorrowError(_) => {
+                matches!(other, ChimeraRuntimeFailure::BorrowError(_))
             }
             ChimeraRuntimeFailure::InvalidHeader(_, _) => {
                 matches!(other, ChimeraRuntimeFailure::InvalidHeader(_, _))
@@ -205,7 +205,7 @@ impl ChimeraRuntimeFailure {
             ChimeraRuntimeFailure::BadSubfieldAccess(_, _, _) => "BadSubfieldAccess",
             ChimeraRuntimeFailure::TriedToIndexWithNonNumber(_) => "TriedToIndexWithNonNumber",
             ChimeraRuntimeFailure::OutOfBounds(_) => "OutOfBounds",
-            ChimeraRuntimeFailure::BorrowError(_, _) => "BorrowError",
+            ChimeraRuntimeFailure::BorrowError(_) => "BorrowError",
             ChimeraRuntimeFailure::InvalidHeader(_, _) => "InvalidHeader",
         }
     }

--- a/src/testing/chs_files/failing_test.chs
+++ b/src/testing/chs_files/failing_test.chs
@@ -38,3 +38,9 @@ case failing_error_message_formatted_string() {
     var num = LITERAL 2;
     ASSERT EQUALS 1 2 "Expected 1 to equal (num)";
 }
+
+[test]
+case assert_on_formatted_string() {
+    var foo = LITERAL "hello";
+    ASSERT EQUALS "foo" "thing '(foo)'";
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -230,8 +230,8 @@ mod testing {
         let (res, _std_write, err_write) = results_from_filename(filename);
         assert_eq!(
             res.len(),
-            7,
-            "Expected to get 7 test results when running {} which has 7 outermost test cases",
+            8,
+            "Expected to get 8 test results when running {} which has 8 outermost test cases",
             filename
         );
         assert_eq!(res[0].subtest_results.len(), 0, "Test case {} of file {} should have no subtest_results even though it has a nested test case, as it should have failed before reaching the nested case", res[0].test_name(), filename);
@@ -281,12 +281,16 @@ mod testing {
         let lines = err_write.str_lines();
         assert_eq!(
             lines[5].trim(),
-            "FAILURE on line 0: Custom error message - Expected value 1 to equal value '2'"
+            "FAILURE on line 0: Custom error message - Expected value '1' to equal value '2'"
         );
         assert_eq!(
             lines[6].trim(),
-            "FAILURE on line 1: Expected 1 to equal 2 - Expected value 1 to equal value '2'"
+            "FAILURE on line 1: Expected 1 to equal 2 - Expected value '1' to equal value '2'"
         );
+        assert_eq!(
+            lines[7].trim(),
+            "FAILURE on line 1: Expected value 'foo' to equal formatted string 'thing 'hello''"
+        )
     }
 
     #[test]

--- a/src/util/client.rs
+++ b/src/util/client.rs
@@ -2,7 +2,6 @@ use crate::abstract_syntax_tree::{HTTPVerb, HttpCommand};
 use crate::err_handle::ChimeraRuntimeFailure;
 use crate::frontend::Context;
 use crate::literal::{Collection, Data, DataKind, Literal, NumberKind};
-use crate::variable_map::VariableMap;
 use reqwest;
 use std::collections::HashMap;
 
@@ -12,7 +11,6 @@ pub trait WebClient {
         &self,
         context: &Context,
         http_command: HttpCommand,
-        variable_map: &VariableMap,
     ) -> Result<DataKind, ChimeraRuntimeFailure>;
 }
 
@@ -36,11 +34,10 @@ impl WebClient for RealClient {
         &self,
         context: &Context,
         http_command: HttpCommand,
-        variable_map: &VariableMap,
     ) -> Result<DataKind, ChimeraRuntimeFailure> {
-        let resolved_path = http_command.resolve_path(context, variable_map)?;
-        let body_map = http_command.resolve_body(context, variable_map)?;
-        let headers = http_command.resolve_header(context, variable_map)?;
+        let resolved_path = http_command.resolve_path(context)?;
+        let body_map = http_command.resolve_body(context)?;
+        let headers = http_command.resolve_header(context)?;
 
         // Make the web request
         let res = match http_command.verb {

--- a/src/variable_map.rs
+++ b/src/variable_map.rs
@@ -57,7 +57,7 @@ impl VariableMap {
         key: &str,
     ) -> Result<RefMut<DataKind>, ChimeraRuntimeFailure> {
         match self.map.get(key) {
-            Some(var_value) => var_value.borrow_mut(context),
+            Some(var_value) => var_value.borrow_mut(),
             None => Err(ChimeraRuntimeFailure::VarNotFound(
                 key.to_owned(),
                 context.current_line,


### PR DESCRIPTION
Refactor to remove the usage of variable map in all signatures, fold it into the context object. Fix error printing when using a formatted string to no longer debug print and instead resolve the string